### PR TITLE
chore: amend devcontainer.json to provide usb passthrough if needed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,6 +59,7 @@
   "postStartCommand": "/bin/zsh",
   "runArgs": [
     "--network=host",
+    "--privileged",
     "--env-file",
     "${localWorkspaceFolder}/.devcontainer/.env.config"
   ]


### PR DESCRIPTION
chore: amend devcontainer.json to provide usb passthrough if needed